### PR TITLE
Fixed ReDoS (Regex Denial of Service)

### DIFF
--- a/lib/dns-sync.js
+++ b/lib/dns-sync.js
@@ -3,10 +3,11 @@
 var util = require('util'),
     path = require('path'),
     shell = require('shelljs'),
+    RE2 = require('re2'),
     debug = require('debug')('dns-sync');
 
 //source - http://stackoverflow.com/questions/106179/regular-expression-to-match-dns-hostname-or-ip-address
-var ValidHostnameRegex = new RegExp("^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$");
+var ValidHostnameRegex = new RE2("^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$");
 
 // https://nodejs.org/api/dns.html#dns_dns_resolve_hostname_rrtype_callback
 var RRecordTypes = [

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "readmeFilename": "README.md",
   "dependencies": {
     "debug": "^4",
+    "re2": "^1.15.4",
     "shelljs": "~0.8"
   },
   "devDependencies": {


### PR DESCRIPTION
### 📊 Metadata *

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-node-dns-sync

### ⚙️ Description *

The project `node-dns-sync` was validating hostnames with a regex vulnerable to **ReDoS** (Regex Denial of Service).

### 💻 Technical Description *

The implemented Regex pattern to validate hostnames is vulnerable to ReDoS:

```javascript
/^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]).)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9-]*[A-Za-z0-9])$/
```

Using a long string to make it pass through this regex will lead to **Denial of Service**.

### 🐛 Proof of Concept (PoC) *

**Refer:** https://github.com/skoranga/node-dns-sync/issues/5

### 🔥 Proof of Fix (PoF) *

As the used Regex is perfect to validate a hostname but just vulnerable to ReDoS, I implemented [`node-re2`](https://www.npmjs.com/package/re2) instead of the JavaScript `RegExp()` function as `re2` can convert a vulnerable Regex pattern to a safe one preventing any backtracking regular expressions/attacks.

:books: **Reference:**
- https://www.npmjs.com/package/re2#standard-features
- https://stackoverflow.com/questions/106179/regular-expression-to-match-dns-hostname-or-ip-address

### 👍 User Acceptance Testing (UAT)

Replaced the usage of `RegExp()` function with a safer regex binding [`node-re2`](https://www.npmjs.com/package/re2#standard-features).
